### PR TITLE
Update pytest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-attrs==20.3.0
-iniconfig==1.1.1
-packaging==20.8
-pluggy==0.13.1
-py==1.10.0
-pyparsing==2.4.7
-pytest==6.2.1
-toml==0.10.2
+iniconfig==2.0.0
+packaging==24.2
+pluggy==1.5.0
+pytest==8.3.4


### PR DESCRIPTION
This repo is still linked in Learn as an activity though we have not been using it. Updating pytest in case any students want to clone it down and use it as a playground/practice.